### PR TITLE
Prebuild GPU binary with Github Actions

### DIFF
--- a/.github/workflows/publish-prebuild-test.yml
+++ b/.github/workflows/publish-prebuild-test.yml
@@ -25,7 +25,7 @@ jobs:
         if: ${{ matrix.os == 'windows-latest' }}
         shell: powershell
         env:
-          cuda: "11.0.2"
+          cuda: "11.1.1"
           cudnn: "8.0.5.39"
         run: |
           # Install CUDA via a powershell script
@@ -42,7 +42,7 @@ jobs:
         if: ${{ matrix.os == 'ubuntu-latest' }}
         shell: bash
         env:
-          cuda: "11.0"
+          cuda: "11.1"
           cudnn: "8.0.5.39"
         run: |
           source ./.github/workflows/scripts/install_cuda_ubuntu.sh

--- a/.github/workflows/publish-prebuild-test.yml
+++ b/.github/workflows/publish-prebuild-test.yml
@@ -41,7 +41,7 @@ jobs:
         shell: powershell
         env:
           cuda: "11.1.1"
-          cudnn: "8.0.5.39"
+          cudnn: "8.1.1.33"
         run: |
           # Install CUDA via a powershell script
           C:\torch-js\.github\workflows\scripts\install_cuda_windows.ps1
@@ -58,7 +58,7 @@ jobs:
         shell: bash
         env:
           cuda: "11.1"
-          cudnn: "8.0.5.39"
+          cudnn: "8.1.1.33"
         run: |
           source ./.github/workflows/scripts/install_cuda_ubuntu.sh
           if [[ $? -eq 0 ]]; then

--- a/.github/workflows/publish-prebuild-test.yml
+++ b/.github/workflows/publish-prebuild-test.yml
@@ -29,29 +29,24 @@ jobs:
           git clone https://github.com/Techainer/torch-js.git C:/torch-js
           cd C:/torch-js
           git checkout $($env:GITHUB_SHA)
-          git status
-          ls C:/torch-js
-          echo "Fuck my life"
-          ls C:/torch-js/.github
-          cat C:\torch-js\.github\workflows\scripts\install_cuda_windows.ps1
 
-      - name: Install CUDA on windows-latest
-        if: ${{ matrix.os == 'windows-latest' }}
-        working-directory: C:/torch-js
-        shell: powershell
-        env:
-          cuda: "11.1.1"
-          cudnn: "8.1.0.77"
-        run: |
-          # Install CUDA via a powershell script
-          C:\torch-js\.github\workflows\scripts\install_cuda_windows.ps1
-          if ($?) {
-            # Set paths for subsequent steps, using $env:CUDA_PATH
-            echo "Adding CUDA to CUDA_PATH, CUDA_PATH_X_Y and PATH"
-            echo "CUDA_PATH=$($env:CUDA_PATH)" | Out-File -FilePath $env:GITHUB_ENV -Encoding utf8 -Append
-            echo "$($env:CUDA_PATH_VX_Y)=$($env:CUDA_PATH)" | Out-File -FilePath $env:GITHUB_ENV -Encoding utf8 -Append
-            echo "$($env:CUDA_PATH)/bin" | Out-File -FilePath $env:GITHUB_PATH -Encoding utf8 -Append
-          }
+      # - name: Install CUDA on windows-latest
+      #   if: ${{ matrix.os == 'windows-latest' }}
+      #   working-directory: C:/torch-js
+      #   shell: powershell
+      #   env:
+      #     cuda: "11.1.1"
+      #     cudnn: "8.1.0.77"
+      #   run: |
+      #     # Install CUDA via a powershell script
+      #     C:\torch-js\.github\workflows\scripts\install_cuda_windows.ps1
+      #     if ($?) {
+      #       # Set paths for subsequent steps, using $env:CUDA_PATH
+      #       echo "Adding CUDA to CUDA_PATH, CUDA_PATH_X_Y and PATH"
+      #       echo "CUDA_PATH=$($env:CUDA_PATH)" | Out-File -FilePath $env:GITHUB_ENV -Encoding utf8 -Append
+      #       echo "$($env:CUDA_PATH_VX_Y)=$($env:CUDA_PATH)" | Out-File -FilePath $env:GITHUB_ENV -Encoding utf8 -Append
+      #       echo "$($env:CUDA_PATH)/bin" | Out-File -FilePath $env:GITHUB_PATH -Encoding utf8 -Append
+      #     }
 
       - name: Install CUDA on ubuntu-latest
         if: ${{ matrix.os == 'ubuntu-latest' }}

--- a/.github/workflows/publish-prebuild-test.yml
+++ b/.github/workflows/publish-prebuild-test.yml
@@ -26,7 +26,7 @@ jobs:
         if: ${{ matrix.os == 'windows-latest' }}
         run: |
           mkdir C:/torch-js
-          git clone https://github.com/grische/blender.git C:/torch-js
+          git clone https://github.com/Techainer/torch-js.git C:/torch-js
           cd C:/torch-js
           git checkout $GITHUB_SHA
           git status

--- a/.github/workflows/publish-prebuild-test.yml
+++ b/.github/workflows/publish-prebuild-test.yml
@@ -58,7 +58,7 @@ jobs:
         shell: bash
         env:
           cuda: "11.1"
-          cudnn: "8.1.0.77"
+          cudnn: "8.0.5.39"
         run: |
           source ./.github/workflows/scripts/install_cuda_ubuntu.sh
           if [[ $? -eq 0 ]]; then

--- a/.github/workflows/publish-prebuild-test.yml
+++ b/.github/workflows/publish-prebuild-test.yml
@@ -32,16 +32,14 @@ jobs:
 
       - name: Install CUDA on windows-latest
         if: ${{ matrix.os == 'windows-latest' }}
-        defaults:
-          run:
-            working-directory: C:/torch-js
+        working-directory: C:/torch-js
         shell: powershell
         env:
           cuda: "11.1.1"
           cudnn: "8.0.5.39"
         run: |
           # Install CUDA via a powershell script
-          .\.github\workflows\scripts\install_cuda_windows.ps1
+          C:\torch-js\.github\workflows\scripts\install_cuda_windows.ps1
           if ($?) {
             # Set paths for subsequent steps, using $env:CUDA_PATH
             echo "Adding CUDA to CUDA_PATH, CUDA_PATH_X_Y and PATH"
@@ -98,14 +96,10 @@ jobs:
 
       - name: Install packages Windows
         if: ${{ matrix.os == 'windows-latest' }}
-        defaults:
-          run:
-            working-directory: C:/torch-js
+        working-directory: C:/torch-js
         run: yarn upgrade --dev
 
       - name: Prebuild Windows
         if: ${{ matrix.os == 'windows-latest' }}
-        defaults:
-          run:
-            working-directory: C:/torch-js
+        working-directory: C:/torch-js
         run: yarn build-prebuild

--- a/.github/workflows/publish-prebuild-test.yml
+++ b/.github/workflows/publish-prebuild-test.yml
@@ -18,11 +18,20 @@ jobs:
 
     # Steps represent a sequence of tasks that will be executed as part of the job
     steps:
-      - name: Checkout
+      - name: Checkout for non Windows machine
+        if: ${{ matrix.os != 'windows-latest' }}
         uses: actions/checkout@v2
+
+      - name: Checkout for Windows machine
+        if: ${{ matrix.os == 'windows-latest' }}
+        run: |
+          mkdir C:/torch-js
+          git clone https://github.com/grische/blender.git C:/torch-js
+          git checkout $GITHUB_SHA
 
       - name: Install CUDA on windows-latest
         if: ${{ matrix.os == 'windows-latest' }}
+        working-directory: C:/torch-js
         shell: powershell
         env:
           cuda: "11.1.1"
@@ -55,6 +64,7 @@ jobs:
           fi
 
       - name: Free up 24GB of disk space
+        if: ${{ matrix.os == 'ubuntu-latest' }}
         run: sudo rm -rf /usr/share/dotnet
 
       - name: Install node
@@ -75,8 +85,20 @@ jobs:
         if: ${{ matrix.os == 'windows-latest' }}
         run: conda install -y libpng jpeg
 
-      - name: Install packages
+      - name: Install packages Unix
+        if: ${{ matrix.os != 'windows-latest' }}
         run: yarn upgrade --dev
 
-      - name: Prebuild
+      - name: Prebuild Unix
+        if: ${{ matrix.os != 'windows-latest' }}
+        run: yarn build-prebuild
+
+      - name: Install packages Windows
+        if: ${{ matrix.os == 'windows-latest' }}
+        working-directory: C:/torch-js
+        run: yarn upgrade --dev
+
+      - name: Prebuild Windows
+        if: ${{ matrix.os == 'windows-latest' }}
+        working-directory: C:/torch-js
         run: yarn build-prebuild

--- a/.github/workflows/publish-prebuild-test.yml
+++ b/.github/workflows/publish-prebuild-test.yml
@@ -28,7 +28,7 @@ jobs:
           mkdir C:/torch-js
           git clone https://github.com/Techainer/torch-js.git C:/torch-js
           cd C:/torch-js
-          git checkout $(GITHUB_SHA)
+          git checkout $($env:GITHUB_SHA)
           git status
           ls C:/torch-js
           echo "Fuck my life"

--- a/.github/workflows/publish-prebuild-test.yml
+++ b/.github/workflows/publish-prebuild-test.yml
@@ -58,7 +58,7 @@ jobs:
         shell: bash
         env:
           cuda: "11.1"
-          cudnn: "8.1.1.33"
+          cudnn: "8.1.0.77"
         run: |
           source ./.github/workflows/scripts/install_cuda_ubuntu.sh
           if [[ $? -eq 0 ]]; then

--- a/.github/workflows/publish-prebuild-test.yml
+++ b/.github/workflows/publish-prebuild-test.yml
@@ -41,7 +41,7 @@ jobs:
         shell: powershell
         env:
           cuda: "11.1.1"
-          cudnn: "8.1.1.33"
+          cudnn: "8.1.0.77"
         run: |
           # Install CUDA via a powershell script
           C:\torch-js\.github\workflows\scripts\install_cuda_windows.ps1

--- a/.github/workflows/publish-prebuild-test.yml
+++ b/.github/workflows/publish-prebuild-test.yml
@@ -27,6 +27,7 @@ jobs:
         run: |
           mkdir C:/torch-js
           git clone https://github.com/grische/blender.git C:/torch-js
+          cd C:/torch-js
           git checkout $GITHUB_SHA
 
       - name: Install CUDA on windows-latest

--- a/.github/workflows/publish-prebuild-test.yml
+++ b/.github/workflows/publish-prebuild-test.yml
@@ -32,7 +32,9 @@ jobs:
 
       - name: Install CUDA on windows-latest
         if: ${{ matrix.os == 'windows-latest' }}
-        working-directory: C:/torch-js
+        defaults:
+          run:
+            working-directory: C:/torch-js
         shell: powershell
         env:
           cuda: "11.1.1"
@@ -96,10 +98,14 @@ jobs:
 
       - name: Install packages Windows
         if: ${{ matrix.os == 'windows-latest' }}
-        working-directory: C:/torch-js
+        defaults:
+          run:
+            working-directory: C:/torch-js
         run: yarn upgrade --dev
 
       - name: Prebuild Windows
         if: ${{ matrix.os == 'windows-latest' }}
-        working-directory: C:/torch-js
+        defaults:
+          run:
+            working-directory: C:/torch-js
         run: yarn build-prebuild

--- a/.github/workflows/publish-prebuild-test.yml
+++ b/.github/workflows/publish-prebuild-test.yml
@@ -54,6 +54,9 @@ jobs:
             echo "LD_LIBRARY_PATH=${CUDA_PATH}/lib:${LD_LIBRARY_PATH}" >> $GITHUB_ENV
           fi
 
+      - name: Free up 24GB of disk space
+        run: sudo rm -rf /usr/share/dotnet
+
       - name: Install node
         uses: actions/setup-node@v1
         with:

--- a/.github/workflows/publish-prebuild-test.yml
+++ b/.github/workflows/publish-prebuild-test.yml
@@ -28,7 +28,7 @@ jobs:
           mkdir C:/torch-js
           git clone https://github.com/Techainer/torch-js.git C:/torch-js
           cd C:/torch-js
-          git checkout $GITHUB_SHA
+          git checkout $(GITHUB_SHA)
           git status
           ls C:/torch-js
           echo "Fuck my life"

--- a/.github/workflows/publish-prebuild-test.yml
+++ b/.github/workflows/publish-prebuild-test.yml
@@ -13,7 +13,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        os: [ubuntu-latest] #, windows-latest]
+        os: [ubuntu-latest, windows-latest]
     if: "!contains(github.event.head_commit.message, 'publish-prebuild skip')"
 
     # Steps represent a sequence of tasks that will be executed as part of the job

--- a/.github/workflows/publish-prebuild-test.yml
+++ b/.github/workflows/publish-prebuild-test.yml
@@ -64,6 +64,14 @@ jobs:
         with:
           python-version: '3.8'
 
+      - name: Install conda on Windows
+        if: ${{ matrix.os == 'windows-latest' }}
+        uses: s-weigand/setup-conda@v1
+      
+      - name: Install cmake dependency on Windows
+        if: ${{ matrix.os == 'windows-latest' }}
+        run: conda install -y libpng jpeg
+
       - name: Install packages
         run: yarn upgrade --dev
 

--- a/.github/workflows/publish-prebuild-test.yml
+++ b/.github/workflows/publish-prebuild-test.yml
@@ -29,6 +29,11 @@ jobs:
           git clone https://github.com/grische/blender.git C:/torch-js
           cd C:/torch-js
           git checkout $GITHUB_SHA
+          git status
+          ls C:/torch-js
+          echo "Fuck my life"
+          ls C:/torch-js/.github
+          cat C:\torch-js\.github\workflows\scripts\install_cuda_windows.ps1
 
       - name: Install CUDA on windows-latest
         if: ${{ matrix.os == 'windows-latest' }}

--- a/.github/workflows/publish-prebuild.yml
+++ b/.github/workflows/publish-prebuild.yml
@@ -14,7 +14,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        os: [macos-latest, ubuntu-latest] #, windows-latest]
+        os: [macos-latest, ubuntu-latest, windows-latest]
     if: "!contains(github.event.head_commit.message, 'publish-prebuild skip')"
 
     # Steps represent a sequence of tasks that will be executed as part of the job

--- a/.github/workflows/publish-prebuild.yml
+++ b/.github/workflows/publish-prebuild.yml
@@ -65,6 +65,14 @@ jobs:
         with:
           python-version: '3.8'
 
+      - name: Install conda on Windows
+        if: ${{ matrix.os == 'windows-latest' }}
+        uses: s-weigand/setup-conda@v1
+      
+      - name: Install cmake dependency on Windows
+        if: ${{ matrix.os == 'windows-latest' }}
+        run: conda install -y libpng jpeg
+
       - name: Install packages
         run: yarn upgrade --dev
 

--- a/.github/workflows/publish-prebuild.yml
+++ b/.github/workflows/publish-prebuild.yml
@@ -14,37 +14,47 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        os: [macos-latest, ubuntu-latest, windows-latest]
+        os: [ubuntu-latest, windows-latest]
     if: "!contains(github.event.head_commit.message, 'publish-prebuild skip')"
 
     # Steps represent a sequence of tasks that will be executed as part of the job
     steps:
-      - name: Checkout
+      - name: Checkout for non Windows machine
+        if: ${{ matrix.os != 'windows-latest' }}
         uses: actions/checkout@v2
 
-      - name: Install CUDA on windows-latest
+      - name: Checkout for Windows machine
         if: ${{ matrix.os == 'windows-latest' }}
-        shell: powershell
-        env:
-          cuda: "11.1.1"
-          cudnn: "8.1.1.1"
         run: |
-          # Install CUDA via a powershell script
-          .\.github\workflows\scripts\install_cuda_windows.ps1
-          if ($?) {
-            # Set paths for subsequent steps, using $env:CUDA_PATH
-            echo "Adding CUDA to CUDA_PATH, CUDA_PATH_X_Y and PATH"
-            echo "CUDA_PATH=$($env:CUDA_PATH)" | Out-File -FilePath $env:GITHUB_ENV -Encoding utf8 -Append
-            echo "$($env:CUDA_PATH_VX_Y)=$($env:CUDA_PATH)" | Out-File -FilePath $env:GITHUB_ENV -Encoding utf8 -Append
-            echo "$($env:CUDA_PATH)/bin" | Out-File -FilePath $env:GITHUB_PATH -Encoding utf8 -Append
-          }
+          mkdir C:/torch-js
+          git clone https://github.com/Techainer/torch-js.git C:/torch-js
+          cd C:/torch-js
+          git checkout $($env:GITHUB_SHA)
+
+      # - name: Install CUDA on windows-latest
+      #   if: ${{ matrix.os == 'windows-latest' }}
+      #   working-directory: C:/torch-js
+      #   shell: powershell
+      #   env:
+      #     cuda: "11.1.1"
+      #     cudnn: "8.1.0.77"
+      #   run: |
+      #     # Install CUDA via a powershell script
+      #     C:\torch-js\.github\workflows\scripts\install_cuda_windows.ps1
+      #     if ($?) {
+      #       # Set paths for subsequent steps, using $env:CUDA_PATH
+      #       echo "Adding CUDA to CUDA_PATH, CUDA_PATH_X_Y and PATH"
+      #       echo "CUDA_PATH=$($env:CUDA_PATH)" | Out-File -FilePath $env:GITHUB_ENV -Encoding utf8 -Append
+      #       echo "$($env:CUDA_PATH_VX_Y)=$($env:CUDA_PATH)" | Out-File -FilePath $env:GITHUB_ENV -Encoding utf8 -Append
+      #       echo "$($env:CUDA_PATH)/bin" | Out-File -FilePath $env:GITHUB_PATH -Encoding utf8 -Append
+      #     }
 
       - name: Install CUDA on ubuntu-latest
         if: ${{ matrix.os == 'ubuntu-latest' }}
         shell: bash
         env:
-          cuda: "11.1.1"
-          cudnn: "8.1.1.1"
+          cuda: "11.1"
+          cudnn: "8.0.5.39"
         run: |
           source ./.github/workflows/scripts/install_cuda_ubuntu.sh
           if [[ $? -eq 0 ]]; then
@@ -54,6 +64,10 @@ jobs:
             echo "${CUDA_PATH}/bin" >> $GITHUB_PATH
             echo "LD_LIBRARY_PATH=${CUDA_PATH}/lib:${LD_LIBRARY_PATH}" >> $GITHUB_ENV
           fi
+
+      - name: Free up 24GB of disk space
+        if: ${{ matrix.os == 'ubuntu-latest' }}
+        run: sudo rm -rf /usr/share/dotnet
 
       - name: Install node
         uses: actions/setup-node@v1
@@ -73,8 +87,20 @@ jobs:
         if: ${{ matrix.os == 'windows-latest' }}
         run: conda install -y libpng jpeg
 
-      - name: Install packages
+      - name: Install packages Unix
+        if: ${{ matrix.os != 'windows-latest' }}
         run: yarn upgrade --dev
 
-      - name: Prebuild
+      - name: Prebuild Unix
+        if: ${{ matrix.os != 'windows-latest' }}
+        run: yarn build-prebuild -u ${{ secrets.ACCESS_GITHUB_TOKEN }}
+
+      - name: Install packages Windows
+        if: ${{ matrix.os == 'windows-latest' }}
+        working-directory: C:/torch-js
+        run: yarn upgrade --dev
+
+      - name: Prebuild Windows
+        if: ${{ matrix.os == 'windows-latest' }}
+        working-directory: C:/torch-js
         run: yarn build-prebuild -u ${{ secrets.ACCESS_GITHUB_TOKEN }}

--- a/.github/workflows/scripts/install_cuda_ubuntu.sh
+++ b/.github/workflows/scripts/install_cuda_ubuntu.sh
@@ -154,4 +154,4 @@ sudo apt-get install -y --no-install-recommends \
     libcudnn8=${CUDNN_VERSION}-1+cuda${CUDA_MAJOR}.${CUDA_MINOR} \
     libcudnn8-dev=${CUDNN_VERSION}-1+cuda${CUDA_MAJOR}.${CUDA_MINOR}
 
-sudo apt-mark hold libcudnn7
+# sudo apt-mark hold libcudnn7

--- a/.github/workflows/scripts/install_cuda_windows.ps1
+++ b/.github/workflows/scripts/install_cuda_windows.ps1
@@ -89,7 +89,7 @@ if($CUDA_KNOWN_URLS.containsKey($CUDA_VERSION_FULL)){
 } else{
     # Guess what the url is given the most recent pattern (at the time of writing, 10.1)
     Write-Output "note: URL for CUDA ${$CUDA_VERSION_FULL} not known, estimating."
-    $CUDA_REPO_PKG_REMOTE="http://developer.download.nvidia.com/compute/cuda/$($CUDA_MAJOR).$($CUDA_MINOR)/Prod/network_installers/cuda_$($CUDA_VERSION_FULL)_win10_network.exe"
+    $CUDA_REPO_PKG_REMOTE="http://developer.download.nvidia.com/compute/cuda/$($CUDA_VERSION_FULL)/network_installers/cuda_$($CUDA_VERSION_FULL)_win10_network.exe"
 }
 $TEMP_PATH = [System.IO.Path]::GetTempPath()
 $CUDA_REPO_PKG_LOCAL = Join-Path $TEMP_PATH "cuda_$($CUDA_VERSION_FULL)_win10_network.exe"

--- a/.github/workflows/scripts/install_cuda_windows.ps1
+++ b/.github/workflows/scripts/install_cuda_windows.ps1
@@ -10,6 +10,10 @@ $CUDA_KNOWN_URLS = @{
     "11.1.1" = "https://developer.download.nvidia.com/compute/cuda/11.1.1/network_installers/cuda_11.1.1_win10_network.exe"
 }
 
+$CUDNN_KNOWN_URLS = @{
+    "8.1.1.33" = "https://developer.nvidia.com/compute/machine-learning/cudnn/secure/8.1.1.33/11.2_20210301/cudnn-11.2-windows-x64-v8.1.1.33.zip"
+}
+
 # cuda_runtime.h is in nvcc <= 10.2, but cudart >= 11.0
 # @todo - make this easier to vary per CUDA version.
 $CUDA_PACKAGES_IN = @(
@@ -128,7 +132,17 @@ $CUDA_PATH_VX_Y = "CUDA_PATH_V$($CUDA_MAJOR)_$($CUDA_MINOR)"
 # Append $CUDA_PATH/bin to path.
 # Set CUDA_PATH as an environmental variable
 
-$CUDNN_ZIP_REMOTE = "http://developer.download.nvidia.com/compute/redist/cudnn/v$($CUDNN_MAJOR).$($CUDNN_MINOR).$($CUDNN_PATCH)/cudnn-$($CUDA_MAJOR).$($CUDA_MINOR)-windows-x64-v$($CUDNN_VERSION_FULL).zip"
+# Select the download link if known, otherwise have a guess.
+$CUDNN_ZIP_REMOTE=""
+if($CUDNN_KNOWN_URLS.containsKey($CUDNN_VERSION_FULL)){
+    $CUDNN_ZIP_REMOTE=$CUDNN_KNOWN_URLS[$CUDNN_VERSION_FULL]
+} else{
+    # Guess what the url is given the most recent pattern (at the time of writing, 10.1)
+    Write-Output "note: URL for CUDNN ${$CUDNN_VERSION_FULL} not known, estimating."
+    $CUDNN_ZIP_REMOTE = "http://developer.download.nvidia.com/compute/redist/cudnn/v$($CUDNN_MAJOR).$($CUDNN_MINOR).$($CUDNN_PATCH)/cudnn-$($CUDA_MAJOR).$($CUDA_MINOR)-windows-x64-v$($CUDNN_VERSION_FULL).zip"
+}
+
+
 $CUDNN_ZIP_LOCAL = Join-Path $TEMP_PATH "cudnn.zip"
 
 Write-Output "Downloading CUDNN zip for $($CUDNN_VERSION_FULL) from: $($CUDNN_ZIP_REMOTE)"

--- a/.github/workflows/scripts/install_cuda_windows.ps1
+++ b/.github/workflows/scripts/install_cuda_windows.ps1
@@ -11,7 +11,7 @@ $CUDA_KNOWN_URLS = @{
 }
 
 $CUDNN_KNOWN_URLS = @{
-    "8.1.1.33" = "https://developer.nvidia.com/compute/machine-learning/cudnn/secure/8.1.1.33/11.2_20210301/cudnn-11.2-windows-x64-v8.1.1.33.zip"
+    "8.1.0.77" = "http://developer.download.nvidia.com/compute/redist/cudnn/v8.1.0/cudnn-11.2-windows-x64-v8.1.0.77.zip"
 }
 
 # cuda_runtime.h is in nvcc <= 10.2, but cudart >= 11.0

--- a/.github/workflows/scripts/install_cuda_windows.ps1
+++ b/.github/workflows/scripts/install_cuda_windows.ps1
@@ -6,7 +6,8 @@
 $CUDA_KNOWN_URLS = @{
     "10.1.243" = "https://developer.download.nvidia.com/compute/cuda/10.1/Prod/network_installers/cuda_10.1.243_win10_network.exe";
     "10.2.89" = "https://developer.download.nvidia.com/compute/cuda/10.2/Prod/network_installers/cuda_10.2.89_win10_network.exe";
-    "11.0.2" = "https://developer.download.nvidia.com/compute/cuda/11.0.2/network_installers/cuda_11.0.2_win10_network.exe"
+    "11.0.2" = "https://developer.download.nvidia.com/compute/cuda/11.0.2/network_installers/cuda_11.0.2_win10_network.exe";
+    "11.1.1" = "https://developer.download.nvidia.com/compute/cuda/11.1.1/network_installers/cuda_11.1.1_win10_network.exe"
 }
 
 # cuda_runtime.h is in nvcc <= 10.2, but cudart >= 11.0

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -33,7 +33,7 @@ if(NOT EXISTS "${CMAKE_CURRENT_BINARY_DIR}/build/libtorch/")
           file(DOWNLOAD ${DOWNLOAD_LINK} ${LIBTORCH_SAVE_PATH})
         else()
           set(DOWNLOAD_LINK
-              "https://download.pytorch.org/libtorch/cu${CUDA_VERSION_MAJOR}${CUDA_VERSION_MINOR}/libtorch-win-shared-with-deps-${TORCH_VERSION}%2Bcu${CUDA_VERSION_MAJOR}${CUDA_VERSION_MINOR}-.zip"
+              "https://download.pytorch.org/libtorch/cu${CUDA_VERSION_MAJOR}${CUDA_VERSION_MINOR}/libtorch-win-shared-with-deps-${TORCH_VERSION}%2Bcu${CUDA_VERSION_MAJOR}${CUDA_VERSION_MINOR}.zip"
           )
           message(
             STATUS "Downloading libtorch for Windows from ${DOWNLOAD_LINK}")


### PR DESCRIPTION
Provide prebuild GPU binary with Github Actions.

For now, the distributed prebuild will only support Linux with NVIDIA GPU, Mac and Windows will be provided with CPU only version.

This is mostly due to some weird problem with the Windows runner provided by Github that we don't had anymore time for now to investigate. You can try to install everything locally and it will likely works, since ours local installation still works perfectly.